### PR TITLE
fix: don't set flex property for div container inside popup

### DIFF
--- a/src/components/Controls/Controls.scss
+++ b/src/components/Controls/Controls.scss
@@ -24,6 +24,7 @@
 
     &__tooltip-text {
         @include text-size(body-1-short);
+        display: block;
         white-space: nowrap;
     }
 

--- a/src/components/Popup/Popup.scss
+++ b/src/components/Popup/Popup.scss
@@ -5,8 +5,4 @@
     background: var(--yc-color-float-area);
     border-radius: 4px;
     box-shadow: 0 10px 13px var(--yc-color-card-shadow);
-
-    & > div {
-        display: flex;
-    }
 }


### PR DESCRIPTION
Исправляет баг с шириной контента в попапе, изначально этот фикс был для выравнивания текста в тултипах для контролов

До:
<img width="353" alt="Screen Shot 2021-02-01 at 3 48 55 AM" src="https://user-images.githubusercontent.com/62902338/106403618-a7277e80-6440-11eb-92bb-3cfdf9309541.png">

После:
<img width="310" alt="Screen Shot 2021-02-01 at 3 49 10 AM" src="https://user-images.githubusercontent.com/62902338/106403622-a8f14200-6440-11eb-8b03-ef4d62c09a7a.png">

