### PR TITLE
DOCSTOOLS-558

### DIFF
--- a/src/components/DocPage/DocPage.tsx
+++ b/src/components/DocPage/DocPage.tsx
@@ -373,7 +373,10 @@ class DocPage extends React.Component<DocPageInnerProps, DocPageState> {
     private renderAsideMiniToc() {
         const {headings, router, headerHeight, lang, toc} = this.props;
 
-        if (headings.length < 2 || toc.singlePage) {
+        const emptyHeaderOrSinglePage = headings.length === 0 || toc.singlePage;
+        const soloHeaderWithChildren = headings.length === 1 && headings[0].items && headings[0].items.length > 1;
+
+        if (emptyHeaderOrSinglePage || !(soloHeaderWithChildren || headings.length > 2)) {
             return null;
         }
 


### PR DESCRIPTION
Отображение мини-тока, при условии, когда на странице только один heading и у него есть дети (пример - h2 h3 h3 h3)