### PR TITLE
Add ux support for links on TOC branches

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -19,17 +19,26 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({items, className}) => {
     return (
         <nav className={b(null, className)} aria-label="Breadcrumbs">
             <ol className={b('items')}>
-                {items.map(({name}, index, subItems) => (
+                {items.map(({name, url}, index, subItems) => (
                     <li key={index} className={b('item')}>
-                        <span
-                            className={b('text')}
-                            aria-current={index === subItems.length - 1 ? 'page' : undefined}
-                        >
-                            {name}
-                        </span>
+                        {renderItem({name, url}, index === subItems.length - 1)}
                     </li>
                 ))}
             </ol>
         </nav>
     );
 };
+
+function renderItem({name, url}: BreadcrumbItem, isLast: boolean) {
+    const hasUrl = Boolean(url);
+
+    return React.createElement(
+        hasUrl && !isLast ? 'a' : 'span',
+        {
+            className: b('text', {link: hasUrl}),
+            href: url,
+            ['aria-current']: isLast ? 'page' : null,
+        },
+        name,
+    );
+}

--- a/src/components/DocPage/DocPage.tsx
+++ b/src/components/DocPage/DocPage.tsx
@@ -317,7 +317,7 @@ class DocPage extends React.Component<DocPageInnerProps, DocPageState> {
     private renderBreadcrumbs() {
         const {breadcrumbs} = this.props;
 
-        if (!breadcrumbs || breadcrumbs.length === 0) {
+        if (!breadcrumbs || breadcrumbs.length < 2) {
             return null;
         }
 

--- a/src/components/Toc/Toc.scss
+++ b/src/components/Toc/Toc.scss
@@ -101,11 +101,6 @@ $leftOffset: 57px;
                 color: var(--yc-color-text-primary);
             }
 
-            //&_active {
-            //    border-radius: 3px;
-            //    background: var(--yc-color-base-selection);
-            //}
-
             &:not(&_opened) > #{$class}__list {
                 display: none;
             }

--- a/src/components/Toc/Toc.scss
+++ b/src/components/Toc/Toc.scss
@@ -97,47 +97,14 @@ $leftOffset: 57px;
             cursor: pointer;
             user-select: none;
 
-            &-link {
-                display: block;
-                text-decoration: none;
-            }
-
-            &-text {
-                position: relative;
-                padding: 7px 12px 7px 20px;
-                word-break: break-word;
-
-                color: var(--yc-color-text-primary);
-
-                &::before {
-                    content: '';
-                    position: absolute;
-                    top: 0;
-                    right: 0;
-                    // hack: to be shure that it will always start from the left of the TOC
-                    left: -100vw;
-                    height: 100%;
-                }
-
-                &:hover {
-                    border-radius: 3px;
-                    background: var(--yc-color-base-simple-hover);
-                }
-            }
-
-            &-icon {
-                position: absolute;
-                left: 0;
-            }
-
             &_main > *:first-child {
                 color: var(--yc-color-text-primary);
             }
 
-            &_active {
-                border-radius: 3px;
-                background: var(--yc-color-base-selection);
-            }
+            //&_active {
+            //    border-radius: 3px;
+            //    background: var(--yc-color-base-selection);
+            //}
 
             &:not(&_opened) > #{$class}__list {
                 display: none;

--- a/src/components/Toc/TocItemRegistry.ts
+++ b/src/components/Toc/TocItemRegistry.ts
@@ -1,0 +1,78 @@
+import {TocItem} from '../../models';
+
+type NormalizeUrl = (path: string, hash: string | undefined) => string | null | undefined;
+
+export class TocItemRegistry {
+    private itemById: Map<string, TocItem> = new Map();
+
+    private parentById: Map<string, string> = new Map();
+
+    private itemIdByUrl: Map<string, string> = new Map();
+
+    private normalizeUrl: NormalizeUrl;
+
+    constructor(items: TocItem[], normalizeUrl: NormalizeUrl) {
+        this.normalizeUrl = normalizeUrl;
+
+        this.consumeItems(items);
+    }
+
+    getIdByUrl(url: string): string | undefined {
+        return this.itemIdByUrl.get(url);
+    }
+
+    getItemById(id: string): TocItem | undefined {
+        return this.itemById.get(id);
+    }
+
+    getParentId(id: string): string {
+        return this.parentById.get(id) || '';
+    }
+
+    getParentIds(id: string): string[] {
+        const result = [];
+
+        let parentId = this.getParentId(id);
+        while (parentId) {
+            result.push(parentId);
+            parentId = this.getParentId(parentId);
+        }
+
+        return result;
+    }
+
+    getChildIds(id: string): string[] {
+        const item = this.itemById.get(id);
+
+        if (!item) {
+            return [];
+        }
+
+        return (item.items || ([] as TocItem[])).reduce((acc, child) => {
+            return acc.concat([child.id], this.getChildIds(child.id));
+        }, [] as string[]);
+    }
+
+    private consumeItems(items: TocItem[], parent?: TocItem) {
+        items.forEach((item) => {
+            this.itemById.set(item.id, item);
+
+            if (item.href) {
+                const [pathname, hash] = item.href.split('#');
+                const url = this.normalizeUrl(pathname, hash);
+
+                if (url) {
+                    this.itemIdByUrl.set(url, item.id);
+                }
+            }
+
+            if (parent) {
+                this.parentById.set(item.id, parent.id);
+            }
+
+            if (item.items) {
+                this.consumeItems(item.items, item);
+            }
+        });
+    }
+}

--- a/src/components/TocItem/TocItem.scss
+++ b/src/components/TocItem/TocItem.scss
@@ -1,0 +1,45 @@
+@import '../../../styles/variables';
+@import '../../../styles/mixins';
+
+.dc-toc-item {
+    cursor: pointer;
+    user-select: none;
+
+    &__link {
+        display: block;
+        text-decoration: none;
+    }
+
+    &__text {
+        position: relative;
+        padding: 7px 12px 7px 20px;
+        word-break: break-word;
+
+        color: var(--yc-color-text-primary);
+
+        &_active {
+            border-radius: 3px;
+            background: var(--yc-color-base-selection);
+        }
+
+        &::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            right: 0;
+            // hack: to be shure that it will always start from the left of the TOC
+            left: -100vw;
+            height: 100%;
+        }
+
+        &:hover {
+            border-radius: 3px;
+            background: var(--yc-color-base-simple-hover);
+        }
+    }
+
+    &__icon {
+        position: absolute;
+        left: 0;
+    }
+}

--- a/src/components/TocItem/TocItem.tsx
+++ b/src/components/TocItem/TocItem.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import block from 'bem-cn-lite';
+
+import {TocItem as ITocItem} from '../../models';
+import {ToggleArrow} from '../ToggleArrow';
+
+import {isExternalHref} from '../../utils';
+
+import './TocItem.scss';
+
+const b = block('dc-toc-item');
+
+export interface TocItemProps extends ITocItem {
+    id: string;
+    name: string;
+    href?: string;
+    items?: ITocItem[];
+    active: boolean;
+    expandable: boolean;
+    expanded: boolean;
+    openItem: (id: string) => void;
+    closeItem: (id: string) => void;
+}
+
+class TocItem extends React.Component<TocItemProps> {
+    contentRef = React.createRef<HTMLDivElement>();
+
+    render() {
+        const {name, href, active, expandable, expanded} = this.props;
+        const text = <span>{name}</span>;
+        const icon = expandable ? (
+            <ToggleArrow className={b('icon')} open={expanded} thin={true} />
+        ) : null;
+        const content = (
+            <div
+                ref={href ? null : this.contentRef}
+                className={b('text', {active})}
+                onClick={expandable && !href ? this.handleClick : undefined}
+            >
+                {icon}
+                {text}
+            </div>
+        );
+
+        if (!href) {
+            return content;
+        }
+
+        const isExternal = isExternalHref(href);
+        const linkAttributes = {
+            href,
+            target: isExternal ? '_blank' : '_self',
+            rel: isExternal ? 'noopener noreferrer' : undefined,
+        };
+
+        return (
+            <a
+                {...linkAttributes}
+                className={b('link')}
+                onClick={expandable && href ? this.handleClick : undefined}
+                data-router-shallow
+            >
+                {content}
+            </a>
+        );
+    }
+
+    scrollToItem = () => {
+        if (!this.contentRef.current) {
+            return;
+        }
+
+        const itemElement = this.contentRef.current;
+        const itemHeight = itemElement.offsetHeight ?? 0;
+        const itemOffset = itemElement.offsetTop;
+        const scrollableParent = itemElement.offsetParent as HTMLDivElement | null;
+
+        if (!scrollableParent) {
+            return;
+        }
+
+        const scrollableHeight = scrollableParent.offsetHeight;
+        const scrollableOffset = scrollableParent.scrollTop;
+
+        const itemVisible =
+            itemOffset >= scrollableOffset &&
+            itemOffset <= scrollableOffset + scrollableHeight - itemHeight;
+
+        if (!itemVisible) {
+            scrollableParent.scrollTop = itemOffset - Math.floor(scrollableHeight / 2) + itemHeight;
+        }
+    };
+
+    private handleClick = () => {
+        const {id, href, active, expanded, openItem, closeItem} = this.props;
+
+        if (!active && href) {
+            return;
+        }
+
+        if (expanded) {
+            closeItem(id);
+            return;
+        }
+
+        if (!expanded) {
+            openItem(id);
+            return;
+        }
+    };
+}
+
+export default TocItem;

--- a/src/components/TocItem/TocItem.tsx
+++ b/src/components/TocItem/TocItem.tsx
@@ -18,8 +18,7 @@ export interface TocItemProps extends ITocItem {
     active: boolean;
     expandable: boolean;
     expanded: boolean;
-    openItem: (id: string) => void;
-    closeItem: (id: string) => void;
+    toggleItem: (id: string, opened: boolean) => void;
 }
 
 class TocItem extends React.Component<TocItemProps> {
@@ -92,21 +91,13 @@ class TocItem extends React.Component<TocItemProps> {
     };
 
     private handleClick = () => {
-        const {id, href, active, expanded, openItem, closeItem} = this.props;
+        const {id, href, active, expanded, toggleItem} = this.props;
 
         if (!active && href) {
             return;
         }
 
-        if (expanded) {
-            closeItem(id);
-            return;
-        }
-
-        if (!expanded) {
-            openItem(id);
-            return;
-        }
+        toggleItem(id, expanded);
     };
 }
 

--- a/src/components/TocItem/index.ts
+++ b/src/components/TocItem/index.ts
@@ -1,0 +1,2 @@
+export {default as TocItem} from './TocItem';
+export * from './TocItem';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -106,6 +106,7 @@ export interface TocItem {
 
 export interface BreadcrumbItem {
     name: string;
+    url?: string;
 }
 
 export interface Router {


### PR DESCRIPTION
Add ux support for links on TOC branches (not leafs).

Next situation will be handled correctly:
```yaml
title: Some TOC
items:
  - name: Some Branch
    href: ./some/link/path // Previously we ignore this link in UX/UI
    items:
      - name: Some Leaf
        href: ./some/other/link/path 
```

In any words this PR allow to add leading pages as section urls, not as first child of section.
Algorithm:
- If branch is active - on click - collapse branch TOC
- If branch is opened and child is active - on click - activate branch
- If branch is opened and child is not active - on click - activate branch
- If branch is closed (collapsed) (child can't be active this way) - on click - activate branch and expand childs
- If branch is opened - on click in other branch - branch would not be collapsed

Links on branches allow us to make Breadcrumbs clickable.
So this is second part of PR - clickable Breadcrumbs.