### PR TITLE
Common JS instead esnext

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@yandex-cloud/tsconfig/tsconfig",
   "compilerOptions": {
-    "module": "esNext",
+    "module": "commonjs",
     "allowJs": false,
     "importHelpers": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
Для того, чтобы в рантайме в doc-tools подключать react компоненты для ssr, тут нужен commonjs